### PR TITLE
Perform action

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,23 @@ In effect, it interfaces the MiR REST API with `open-rmf`, all without needing t
 
 ## Usage
 
+### Pre-defined RMF variable move mission
+
+Users are required to define a custom mission with a single `Move` action, which has the variables `x`, `y` and `yaw`, attached to the coordinates `x`, `y` and `yaw` respectively. This is the mission that the fleet adapter will use to send move commands to the robot, while modifying the desired `x`, `y` and `yaw` values.
+
+For more information on how to set up missions, actions and variables, please refer to [official guide documents](https://www.manualslib.com/manual/1941073/Mir-Mir250.html?page=150#manual) (this is for the MiR250).
+
+The name of this custom mission, will need to be passed to the fleet adapter through the configuration file, under `rmf_move_mission`, for each robot's `mir_config`.
+
+```yaml
+robots:
+  ROBOT_NAME:
+    mir_config:
+      ...
+      rmf_move_mission: "CUSTOM_MISSION_NAME"
+      ...
+```
+
 ### Example Entry Point
 
 An example usage of the implemented adapter can be found in the `fleet_adapter_mir/fleet_adapter_mir.py` file. It takes in a configuration file and navigation graph, sets everything up, and spins up the fleet adapter.

--- a/configs/mir_config.yaml
+++ b/configs/mir_config.yaml
@@ -11,9 +11,11 @@ robots:
   # So for now, this name is the name used in the script only.
   my_test_robot:
     mir_config:
-      base_url: "http://some_url"
-      user: "some_user"
-      password: "some_password"
+      base_url: "http://some.ip.address/api/v2.0.0/"
+      user: "application/json"
+      password: "Basic HASH_OF_PASSWORD_OBTAINED_AT_API_DOCUMENTATION_PAGE"
+      rmf_move_mission: "rmf_default_move_mission" # This mission must be predefined
+      dock_and_charge_mission: "dock_to_charger" # This mission must be predefined
 
     rmf_config:
       robot_state_update_frequency: 1
@@ -96,4 +98,4 @@ rmf_fleet:
     delivery: False
     clean: False
     finishing_request: "nothing" # [park, charge, nothing]
-    action_categories: ["dock_to_charger", "custom_mission_1"]
+    action_categories: ["custom_mission_1"]

--- a/configs/mir_config.yaml
+++ b/configs/mir_config.yaml
@@ -19,7 +19,8 @@ robots:
       robot_state_update_frequency: 1
       start:
         map_name: "L1"
-
+        max_merge_waypoint_distance: 3.0
+        max_merge_lane_distance: 3.0
         # NOTE(CH3):
         # If you leave these empty, the robot will try to figure it out on init
         # from the MiR reported location.
@@ -28,6 +29,8 @@ robots:
         # ON the waypoint!
         waypoint_index: 0 # Optional
         orientation: 0.0 # Optional, radians
+      charger:
+        waypoint: "charger_waypoint"
 
 
 # NODE CONFIG ==================================================================
@@ -93,3 +96,4 @@ rmf_fleet:
     delivery: False
     clean: False
     finishing_request: "nothing" # [park, charge, nothing]
+    action_categories: ["dock_to_charger", "custom_mission_1"]

--- a/configs/mir_config.yaml
+++ b/configs/mir_config.yaml
@@ -88,3 +88,8 @@ rmf_fleet:
   publish_fleet_state: True
   fleet_state_topic: "fleet_states"
   fleet_state_publish_frequency: 1
+  task_capabilities: # Specify the types of RMF Tasks that robots in this fleet are capable of performing
+    loop: True
+    delivery: False
+    clean: False
+    finishing_request: "nothing" # [park, charge, nothing]

--- a/fleet_adapter_mir/MiRClientAPI.py
+++ b/fleet_adapter_mir/MiRClientAPI.py
@@ -74,10 +74,16 @@ class MirAPI:
         except Exception as err:
             print(f"Other here error: {err}")
 
-    def mission_queue_post(self, mission_id):
+    def mission_queue_post(self, mission_id, full_mission_description=None):
         if not self.connected:
             return
-        data = {"mission_id": mission_id}
+        data = {'mission_id': mission_id}
+        if full_mission_description is not None:
+            data = full_mission_description
+            if mission_id != full_mission_description['mission_id']:
+                print(f'Inconsistent mission id, provided [{mission_id}], full_mission_description: [{full_mission_description}]')
+                return
+
         try:
             response = requests.post(self.prefix + 'mission_queue' , headers = self.headers, data=json.dumps(data), timeout = self.timeout)
             if self.debug:

--- a/fleet_adapter_mir/MiRClientAPI.py
+++ b/fleet_adapter_mir/MiRClientAPI.py
@@ -25,7 +25,7 @@ class MirAPI:
             print(f"HTTP error: {http_err}")
         except Exception as err:
             print(f"Other error: {err}")
-         
+
     def status_get(self):
         if not self.connected:
             return
@@ -49,7 +49,7 @@ class MirAPI:
             print(f"HTTP error: {http_err}")
         except Exception as err:
             print(f"Other error: {err}")
-    
+
     def positions_get(self):
         if not self.connected:
             return
@@ -62,6 +62,17 @@ class MirAPI:
             print(f"HTTP error: {http_err}")
         except Exception as err:
             print(f"Other error: {err}")
+
+    def mission_queue_id_get(self, mission_queue_id):
+        if not self.connected:
+            return
+        try:
+            response = requests.get(self.prefix + f'mission_queue/{mission_queue_id}', headers = self.headers, timeout=self.timeout)
+            return response.json()
+        except HTTPError as http_err:
+            print(f"HTTP error: {http_err}")
+        except Exception as err:
+            print(f"Other here error: {err}")
 
     def mission_queue_post(self, mission_id):
         if not self.connected:
@@ -81,7 +92,7 @@ class MirAPI:
         if not self.connected:
             return
         try:
-            response = requests.post(self.prefix + 'missions/' +mission_id +'/actions' , headers = self.headers, data=json.dumps(body), timeout = self.timeout)
+            response = requests.post(self.prefix + 'missions/' + mission_id +'/actions' , headers = self.headers, data=json.dumps(body), timeout = self.timeout)
             if self.debug:
                 print(f"Response: {response.json()}")
                 print(response.status_code)
@@ -130,7 +141,7 @@ class MirAPI:
             print(f"HTTP error: {http_err}")
         except Exception as err:
             print(f"Other error: {err}")
-                
+
     def mission_queue_delete(self):
         if not self.connected:
             return

--- a/fleet_adapter_mir/MiRCommandHandle.py
+++ b/fleet_adapter_mir/MiRCommandHandle.py
@@ -576,7 +576,7 @@ class MiRCommandHandle(adpt.RobotCommandHandle):
             self.action_check_task_completion = _check_task_completion
 
             # Keep track of perform action
-            self.node.get_logger().warn(f"Robot [{self.name}] starts [{category}] action")
+            self.node.get_logger().info(f"Robot [{self.name}] starts [{category}] action")
             self.action_category = category
             self.action_description = description
             self.action_start_time = self.node.get_clock().now()

--- a/fleet_adapter_mir/MiRCommandHandle.py
+++ b/fleet_adapter_mir/MiRCommandHandle.py
@@ -151,6 +151,8 @@ class MiRCommandHandle(adpt.RobotCommandHandle):
         self.mir_positions = {}  # MiR Place Name-GUID Dict
         self.mir_api = None  # MiR REST API
         self.mir_state = MiRState.PAUSE
+        self.mir_rmf_move_mission = None
+        self.mir_dock_and_charge_mission = None
 
         # Thread Management ===================================================
         # Path queue execution thread
@@ -302,6 +304,9 @@ class MiRCommandHandle(adpt.RobotCommandHandle):
             while ((self.rmf_remaining_path_waypoints or self.paused)
                     or _current_waypoint):
 
+                # DEBUG PRINTOUT
+                # print([str(x[1].graph_index) for x in self.rmf_remaining_path_waypoints])
+                next_mission_wait = 0
                 if not self.paused:  # Skipped if paused
                     if _current_waypoint is None:
                         _, _current_waypoint = (
@@ -411,12 +416,8 @@ class MiRCommandHandle(adpt.RobotCommandHandle):
                                 _next_waypoint.position[1]
                             ]
                         )
-                        _mir_ori_rad = (
-                            math.radians(_next_waypoint.position[2] % 360)
-                            + self.transforms['rmf_to_mir'].get_rotation()
-                        )
-
-                        # NOTE(CH3): MiR Location is sent in Degrees
+                        _mir_ori_rad = \
+                            _next_waypoint.position[2] - self.transforms['rmf_to_mir'].get_rotation()
                         _mir_ori = math.degrees(_mir_ori_rad % (2 * math.pi))
 
                         if _mir_ori > 180.0:
@@ -431,14 +432,15 @@ class MiRCommandHandle(adpt.RobotCommandHandle):
                         )
 
                         print(f"RMF location x:{_next_waypoint.position[0]}"
-                            f"y:{_next_waypoint.position[1]}")
+                            f"y:{_next_waypoint.position[1]} "
+                            f'yaw:{_next_waypoint.position[2]}')
                         print(f'MiR location: {mir_location}')
 
                         print(f"RMF Index: {_next_waypoint.graph_index}")
 
                         self.mir_state = None
 
-                        self.queue_move_coordinate_mission(mir_location)
+                        self.queue_rmf_move_coordinate_mission(mir_location)
                         self.execute_updates()
 
                         # DEBUGGING
@@ -482,7 +484,10 @@ class MiRCommandHandle(adpt.RobotCommandHandle):
 
         def dock_closure():
             if not self.dry_run:
-                self.queue_dock_mission(dock_name)
+                response = self.queue_dock_and_charge_mission()
+                if response is None:
+                    self.rmf_docking_requested = False
+                    self.rmf_docking_executed = False
 
             # Check for docking complete!
             while self.rmf_docking_requested:
@@ -657,122 +662,41 @@ class MiRCommandHandle(adpt.RobotCommandHandle):
     ##########################################################################
     # MISSION METHODS
     ##########################################################################
-    def queue_move_coordinate_mission(self, mir_location):
-        """Add a move mission to the mission queue, creating when needed."""
-        mission_name = ('move_coordinate_to'
-                        f'_{mir_location.x:.3f}'
-                        f'_{mir_location.y:.3f}'
-                        f'_{mir_location.yaw:.3f}')
-
-        # Get mission GUID. If missing, create one and save it.
-        mission_id = self.mir_missions.get(
-            mission_name, self.create_move_coordinate_mission(mir_location)
-        )
-
-        # Queue mission
+    def queue_rmf_move_coordinate_mission(self, mir_location):
+        rmf_move_mission_guid = \
+            self.mir_missions[self.mir_rmf_move_mission]['guid']
+        mission = {
+            'mission_id': rmf_move_mission_guid,
+            'parameters': [
+                {'id': 'x', 'value': mir_location.x, 'label': f'{mir_location.x:.3f}'},
+                {'id': 'y', 'value': mir_location.y, 'label': f'{mir_location.y:.3f}'},
+                {'id': 'yaw', 'value': mir_location.yaw, 'label': f'{mir_location.yaw:.3f}'}
+            ],
+            "priority": 0,
+            "description": "variable move mission to be called by open-rmf"
+        }
         try:
-            mission = mission_id
-            response = self.mir_api.mission_queue_post(mission)
-            self.node.get_logger().info(f'mission_queue_post info: {response}')
+            response = self.mir_api.mission_queue_post(rmf_move_mission_guid, mission)
         except Exception:
             self.node.get_logger().error(
-                '{self.name}: No mission to move coordinates to '
+                '{self.name}: Failed to call rmf_move_mission to '
                 '[{mir_location.x:3f}_{mir_location.y:.3f}]!'
             )
 
+    def queue_dock_and_charge_mission(self):
+        if self.mir_dock_and_charge_mission is None:
+            self.node.get_logger().error('No dock and charge mission defined in MiR config.')
+            return
 
-    def create_move_coordinate_mission(self, mir_location, retries=10):
-        mission_name = ('move_coordinate_to'
-                        f'_{mir_location.x:.3f}'
-                        f'_{mir_location.y:.3f}'
-                        f'_{mir_location.yaw:.3f}')
-
-        mission = {
-            "name": mission_name,
-            "group_id": "mirconst-guid-0000-0001-missiongroup",
-            "description": "automatically created by mir fleet adapter"
-            }
-        response = self.mir_api.missions_post(json.dumps(mission))
-
-        action = {
-            "action_type": "move_to_position",
-            "mission_id": response['guid'],
-            "priority": 1,
-            "parameters":[
-                {"id": "x", "value": mir_location.x},
-                {"id": "y", "value": mir_location.y},
-                {"id": "orientation", "value": mir_location.yaw},
-                {"id": "retries", "value": retries},
-                {"id": "distance_threshold", "value": 0.1}
-            ]
-        }
-
-        self.mir_api.missions_mission_id_actions_post(
-            mission_id=response['guid'],
-            body=action
-        )
-        self.node.get_logger().info(
-            f'{self.name}: '
-            f'Created mission to move coordinate to "{mir_location}"'
-        )
-
-         #NOTE(CH3): Unsure if I should be doing this
-        self.mir_missions[mission_name] = response['guid']
-        return response['guid']
-
-    def queue_dock_mission(self, dock_name):
-        """Add a dock mission to the mission queue, creating when needed."""
-        mission_name = f'dock_to_{dock_name}'
-
-        # Get mission GUID. If missing, create one and save it.
-        mission_id = self.mir_missions.get(mission_name,
-                                       self.create_dock_mission(dock_name))
-        # Queue mission
+        dock_and_charge_mission_guid = \
+            self.mir_missions[self.mir_dock_and_charge_mission]['guid']
         try:
-            mission = mission_id
-            self.mir_api.mission_queue_post(mission)
-        except KeyError:
+            response = self.mir_api.mission_queue_post(dock_and_charge_mission_guid)
+        except Exception:
             self.node.get_logger().error(
-                f'{self.name}: No mission to dock to {dock_name}!'
+                f'{self.name}: Failed to call dock and charge mission '
+                f'{self.mir_dock_and_charge_mission}'
             )
-
-    def create_dock_mission(self, dock_name):
-        """Create, POST, and populate MiR docking mission, then save it."""
-        mission_name = f'dock_to_{dock_name}'
-
-        mission = {
-            # mir const, retrieved with GET /mission_groups
-            "name":mission_name,
-            "group_id":"mirconst-guid-0000-0001-missiongroup",
-            "description":"automatically created by mir fleet handler",
-        }
-        response = self.mir_api.missions_post(json.dumps(mission))
-        self.node.get_logger().info(
-            f'{self.name}: '
-            f'dock mission [{mission_name}] response: {response}'
-        )
-
-        action = {
-            "action_type":"docking",
-            "mission_id":response["guid"],
-            "parameters":[
-                {"id": "marker", "value": dock_name}
-            ],
-            "priority":1
-        }
-        self.mir_api.missions_mission_id_actions_post(
-            mission_id=response["guid"],
-            body=action
-        )
-
-        self.node.get_logger().info(
-            f'created mission to move and dock to: "{dock_name}"'
-        )
-
-        #NOTE(CH3): Unsure if I should be doing this
-        self.mir_missions[mission_name] = response['guid']
-
-        return response['guid']
 
     ##########################################################################
     # RMF CORE INTERACTION METHODS

--- a/fleet_adapter_mir/MiRCommandHandle.py
+++ b/fleet_adapter_mir/MiRCommandHandle.py
@@ -560,7 +560,9 @@ class MiRCommandHandle(adpt.RobotCommandHandle):
                 if m['name'] == category:
                     mission_guid = m['guid']
             if mission_guid is None:
-                self.node.get_logger().error(f'Action category {category} not supported, ignoring')
+                error_str = f'Action category {category} not supported, ignoring'
+                self.node.get_logger().error(error_str)
+                execution.error(error_str)
                 return
 
             # Start mission

--- a/fleet_adapter_mir/MiRCommandHandle.py
+++ b/fleet_adapter_mir/MiRCommandHandle.py
@@ -478,7 +478,7 @@ class MiRCommandHandle(adpt.RobotCommandHandle):
                 if not self.dry_run:
                     api_response = self.mir_api.status_get()
                     self.rmf_docking_executed = (
-                        'docking' in api_response.mission_text.lower())
+                        'docking' in api_response['mission_text'].lower())
                 else:
                     api_response = None
                     self.rmf_docking_executed = False
@@ -488,7 +488,7 @@ class MiRCommandHandle(adpt.RobotCommandHandle):
                 # Docking completed
                 if not self.dry_run:
                     if (self.rmf_docking_executed
-                            and api_response.state_id == MiRState.READY):
+                            and api_response['state_id'] == MiRState.READY):
                         self.rmf_docking_requested = False
                         docking_finished_callback()
 
@@ -677,11 +677,15 @@ class MiRCommandHandle(adpt.RobotCommandHandle):
 
         mission = {
             # mir const, retrieved with GET /mission_groups
-            "group_id":"mirconst-guid-0000-0001-missiongroup",
             "name":mission_name,
+            "group_id":"mirconst-guid-0000-0001-missiongroup",
             "description":"automatically created by mir fleet handler",
         }
-        response = self.mir_api.missions_post(mission)
+        response = self.mir_api.missions_post(json.dumps(mission))
+        self.node.get_logger().info(
+            f'{self.name}: '
+            f'dock mission [{mission_name}] response: {response}'
+        )
 
         action = {
             "action_type":"docking",
@@ -692,7 +696,7 @@ class MiRCommandHandle(adpt.RobotCommandHandle):
             "priority":1
         }
         self.mir_api.missions_mission_id_actions_post(
-            mission_id=response.guid,
+            mission_id=response["guid"],
             body=action
         )
 
@@ -719,8 +723,8 @@ class MiRCommandHandle(adpt.RobotCommandHandle):
                 else:
                     return [0.0, 0.0, 0.0]
 
-        mir_pos = [api_response.position.x, api_response.position.y]
-        mir_ori = api_response.position.orientation
+        mir_pos = [api_response['position']['x'], api_response['position']['y']]
+        mir_ori = api_response['position']['orientation']
 
         # Output is [x, y, yaw]
         if rmf:

--- a/fleet_adapter_mir/MiRCommandHandle.py
+++ b/fleet_adapter_mir/MiRCommandHandle.py
@@ -158,6 +158,11 @@ class MiRCommandHandle(adpt.RobotCommandHandle):
             self.lock_and_execute_updates
         )
 
+    ############################################################################
+    # Init RobotUpdateHandle class member
+    def init_updater(self, updater):
+        self.rmf_updater = updater
+
     ##########################################################################
     # ROBOTCOMMANDHANDLE OVERLOADS (DO NOT CHANGE METHOD SIGNATURES)
     ##########################################################################

--- a/fleet_adapter_mir/MiRCommandHandle.py
+++ b/fleet_adapter_mir/MiRCommandHandle.py
@@ -599,7 +599,7 @@ class MiRCommandHandle(adpt.RobotCommandHandle):
             self.action_category = None
             self.action_description = None
             self.action_start_time = None
-            self.action_check_task_completion
+            self.action_check_task_completion = None
             return
 
         # Still executing perform action

--- a/fleet_adapter_mir/fleet_adapter_mir.py
+++ b/fleet_adapter_mir/fleet_adapter_mir.py
@@ -208,6 +208,20 @@ def create_robot_command_handles(config, handle_data, dry_run=False):
 
             robot.load_mir_missions()
             robot.load_mir_positions()
+
+            # Check that the MiR fleet has defined the RMF move mission,
+            # that this adapter will use repeatedly with varying parameters.
+            rmf_move_mission = mir_config['rmf_move_mission']
+            assert rmf_move_mission in robot.mir_missions, \
+                (f'RMF move mission [{rmf_move_mission}] not yet defined as a mission in MiR fleet')
+            robot.mir_rmf_move_mission = rmf_move_mission
+
+            if 'dock_and_charge_mission' in mir_config:
+                dock_and_charge_mission = mir_config['dock_and_charge_mission']
+                assert dock_and_charge_mission in robot.mir_missions, \
+                (f'Dock and charge mission [{dock_and_charge_mission}] not yet defined as a mission in MiR fleet')
+                robot.mir_dock_and_charge_mission = dock_and_charge_mission
+
         else:
             robot.mir_name = "DUMMY_ROBOT_FOR_DRY_RUN"
 
@@ -235,12 +249,13 @@ def create_robot_command_handles(config, handle_data, dry_run=False):
             )
         assert starts, ("Robot %s can't be placed on the nav graph!"
                         % robot_name)
+        assert len(starts) != 0, (f'No StartSet found for robot: {robot_name}')
 
         # Insert start data into robot
         start = starts[0]
 
         if start.lane is not None:  # If the robot is in a lane
-            robot.rmf_current_lane_index = start.lane.value
+            robot.rmf_current_lane_index = start.lane
             robot.rmf_current_waypoint_index = None
             robot.rmf_target_waypoint_index = None
         else:  # Otherwise, the robot is on a waypoint

--- a/fleet_adapter_mir/fleet_adapter_mir.py
+++ b/fleet_adapter_mir/fleet_adapter_mir.py
@@ -135,11 +135,23 @@ def create_fleet(config,nav_graph_path,task_request_check, mock):
         finishing_request)
     assert ok, ("Unable to set task planner params")
 
-    if task_request_check is None:
-        # Naively accept all delivery requests
-        fleet.accept_task_requests(lambda x: True)
-    else:
-        fleet.accept_task_requests(task_request_check)
+    # Whether to accept custom RMF action tasks
+    # TODO(AA): Refactor this
+    def _consider(description: dict):
+        confirm = adpt.fleet_update_handle.Confirmation()
+
+        if (description['category'] == 'dock_to_48v_charger'):
+            print('accepting dock_to_48v_charger')
+            confirm.accept()
+
+        return confirm
+    fleet.add_performable_action('dock_to_48v_charger', _consider)
+
+    # if task_request_check is None:
+    #     # Naively accept all delivery requests
+    #     fleet.accept_task_requests(lambda x: True)
+    # else:
+    #     fleet.accept_task_requests(task_request_check)
 
     return adapter, fleet, fleet_name, robot_traits, nav_graph
 

--- a/fleet_adapter_mir/fleet_adapter_mir.py
+++ b/fleet_adapter_mir/fleet_adapter_mir.py
@@ -220,18 +220,12 @@ def create_robot_command_handles(config, handle_data, dry_run=False):
         print("MAP_NAME:", start_config['map_name'])
         robot.rmf_map_name = start_config['map_name']
 
-        # INSERT UPDATER ======================================================
-        def updater_inserter(handle_obj, rmf_updater):
-            """Insert a RobotUpdateHandle."""
-            handle_obj.rmf_updater = rmf_updater
-
         handle_data['fleet_handle'].add_robot(
             robot,
             robot.name,
             handle_data['robot_traits'].profile,
             starts,
-            partial(updater_inserter, robot)
-        )
+            lambda rmf_updater: robot.init_updater(rmf_updater))
 
         handle_data['node'].get_logger().info(
             f"successfully initialized robot {robot.name}"


### PR DESCRIPTION
This adds support for `perform_action`, targeting specific mission names that have been predefined in the MiR dashboard, and can be listed in the config file to be called as a `perform_action` task.