### PR TITLE
Use variable move mission

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,23 @@ In effect, it interfaces the MiR REST API with `open-rmf`, all without needing t
 
 ## Usage
 
+### Pre-defined RMF variable move mission
+
+Users are required to define a custom mission with a single `Move` action, which has the variables `x`, `y` and `yaw`, attached to the coordinates `x`, `y` and `yaw` respectively. This is the mission that the fleet adapter will use to send move commands to the robot, while modifying the desired `x`, `y` and `yaw` values.
+
+For more information on how to set up missions, actions and variables, please refer to [official guide documents](https://www.manualslib.com/manual/1941073/Mir-Mir250.html?page=150#manual) (this is for the MiR250).
+
+The name of this custom mission, will need to be passed to the fleet adapter through the configuration file, under `rmf_move_mission`, for each robot's `mir_config`.
+
+```yaml
+robots:
+  ROBOT_NAME:
+    mir_config:
+      ...
+      rmf_move_mission: "CUSTOM_MISSION_NAME"
+      ...
+```
+
 ### Example Entry Point
 
 An example usage of the implemented adapter can be found in the `fleet_adapter_mir/fleet_adapter_mir.py` file. It takes in a configuration file and navigation graph, sets everything up, and spins up the fleet adapter.

--- a/configs/mir_config.yaml
+++ b/configs/mir_config.yaml
@@ -11,9 +11,10 @@ robots:
   # So for now, this name is the name used in the script only.
   my_test_robot:
     mir_config:
-      base_url: "http://some_url"
-      user: "some_user"
-      password: "some_password"
+      base_url: "http://some.ip.address/api/v2.0.0/"
+      user: "application/json"
+      password: "Basic HASH_OF_PASSWORD_OBTAINED_AT_API_DOCUMENTATION_PAGE"
+      variable_move_mission: "rmf_default_move_mission"
 
     rmf_config:
       robot_state_update_frequency: 1

--- a/configs/mir_config.yaml
+++ b/configs/mir_config.yaml
@@ -14,7 +14,8 @@ robots:
       base_url: "http://some.ip.address/api/v2.0.0/"
       user: "application/json"
       password: "Basic HASH_OF_PASSWORD_OBTAINED_AT_API_DOCUMENTATION_PAGE"
-      variable_move_mission: "rmf_default_move_mission"
+      variable_move_mission: "rmf_default_move_mission" # This mission must be predefined
+      dock_and_charge_mission: "dock_to_charger" # This mission must be predefined
 
     rmf_config:
       robot_state_update_frequency: 1
@@ -97,4 +98,4 @@ rmf_fleet:
     delivery: False
     clean: False
     finishing_request: "nothing" # [park, charge, nothing]
-    action_categories: ["dock_to_charger", "custom_mission_1"]
+    action_categories: ["custom_mission_1"]

--- a/configs/mir_config.yaml
+++ b/configs/mir_config.yaml
@@ -14,7 +14,7 @@ robots:
       base_url: "http://some.ip.address/api/v2.0.0/"
       user: "application/json"
       password: "Basic HASH_OF_PASSWORD_OBTAINED_AT_API_DOCUMENTATION_PAGE"
-      variable_move_mission: "rmf_default_move_mission" # This mission must be predefined
+      rmf_move_mission: "rmf_default_move_mission" # This mission must be predefined
       dock_and_charge_mission: "dock_to_charger" # This mission must be predefined
 
     rmf_config:

--- a/fleet_adapter_mir/MiRClientAPI.py
+++ b/fleet_adapter_mir/MiRClientAPI.py
@@ -74,10 +74,16 @@ class MirAPI:
         except Exception as err:
             print(f"Other here error: {err}")
 
-    def mission_queue_post(self, mission_id):
+    def mission_queue_post(self, mission_id, full_mission_description=None):
         if not self.connected:
             return
-        data = {"mission_id": mission_id}
+        data = {'mission_id': mission_id}
+        if full_mission_description is not None:
+            data = full_mission_description
+            if mission_id != full_mission_description['mission_id']:
+                print(f'Inconsistent mission id, provided [{mission_id}], full_mission_description: [{full_mission_description}]')
+                return
+
         try:
             response = requests.post(self.prefix + 'mission_queue' , headers = self.headers, data=json.dumps(data), timeout = self.timeout)
             if self.debug:

--- a/fleet_adapter_mir/MiRCommandHandle.py
+++ b/fleet_adapter_mir/MiRCommandHandle.py
@@ -145,7 +145,7 @@ class MiRCommandHandle(adpt.RobotCommandHandle):
         self.mir_positions = {}  # MiR Place Name-GUID Dict
         self.mir_api = None  # MiR REST API
         self.mir_state = MiRState.PAUSE
-        self.mir_variable_move_mission = None
+        self.mir_rmf_move_mission = None
         self.mir_dock_and_charge_mission = None
 
         # Thread Management ===================================================
@@ -438,7 +438,7 @@ class MiRCommandHandle(adpt.RobotCommandHandle):
 
                         self.mir_state = None
 
-                        self.queue_variable_move_coordinate_mission(mir_location)
+                        self.queue_rmf_move_coordinate_mission(mir_location)
                         self.execute_updates()
 
                         # DEBUGGING
@@ -662,11 +662,11 @@ class MiRCommandHandle(adpt.RobotCommandHandle):
     ##########################################################################
     # MISSION METHODS
     ##########################################################################
-    def queue_variable_move_coordinate_mission(self, mir_location):
-        variable_move_mission_guid = \
-            self.mir_missions[self.mir_variable_move_mission]['guid']
+    def queue_rmf_move_coordinate_mission(self, mir_location):
+        rmf_move_mission_guid = \
+            self.mir_missions[self.mir_rmf_move_mission]['guid']
         mission = {
-            'mission_id': variable_move_mission_guid,
+            'mission_id': rmf_move_mission_guid,
             'parameters': [
                 {'id': 'x', 'value': mir_location.x, 'label': f'{mir_location.x:.3f}'},
                 {'id': 'y', 'value': mir_location.y, 'label': f'{mir_location.y:.3f}'},
@@ -676,10 +676,10 @@ class MiRCommandHandle(adpt.RobotCommandHandle):
             "description": "variable move mission to be called by open-rmf"
         }
         try:
-            response = self.mir_api.mission_queue_post(variable_move_mission_guid, mission)
+            response = self.mir_api.mission_queue_post(rmf_move_mission_guid, mission)
         except Exception:
             self.node.get_logger().error(
-                '{self.name}: Failed to call variable move mission to '
+                '{self.name}: Failed to call rmf_move_mission to '
                 '[{mir_location.x:3f}_{mir_location.y:.3f}]!'
             )
 

--- a/fleet_adapter_mir/MiRCommandHandle.py
+++ b/fleet_adapter_mir/MiRCommandHandle.py
@@ -299,7 +299,7 @@ class MiRCommandHandle(adpt.RobotCommandHandle):
 
                 # DEBUG PRINTOUT
                 # print([str(x[1].graph_index) for x in self.rmf_remaining_path_waypoints])
-
+                next_mission_wait = 0
                 if not self.paused:  # Skipped if paused
                     if _current_waypoint is None:
                         _, _current_waypoint = (
@@ -682,69 +682,6 @@ class MiRCommandHandle(adpt.RobotCommandHandle):
                 '{self.name}: Failed to call variable move mission to '
                 '[{mir_location.x:3f}_{mir_location.y:.3f}]!'
             )
-
-    # def queue_move_coordinate_mission(self, mir_location):
-    #     """Add a move mission to the mission queue, creating when needed."""
-    #     mission_name = ('move_coordinate_to'
-    #                     f'_{mir_location.x:.3f}'
-    #                     f'_{mir_location.y:.3f}'
-    #                     f'_{mir_location.yaw:.3f}')
-
-    #     # Get mission GUID. If missing, create one and save it.
-    #     mission_id = self.mir_missions.get(
-    #         mission_name, self.create_move_coordinate_mission(mir_location)
-    #     )
-
-    #     # Queue mission
-    #     try:
-    #         mission = mission_id
-    #         response = self.mir_api.mission_queue_post(mission)
-    #         self.node.get_logger().info(f'mission_queue_post info: {response}')
-    #     except Exception:
-    #         self.node.get_logger().error(
-    #             '{self.name}: No mission to move coordinates to '
-    #             '[{mir_location.x:3f}_{mir_location.y:.3f}]!'
-    #         )
-
-
-    # def create_move_coordinate_mission(self, mir_location, retries=10):
-    #     mission_name = ('move_coordinate_to'
-    #                     f'_{mir_location.x:.3f}'
-    #                     f'_{mir_location.y:.3f}'
-    #                     f'_{mir_location.yaw:.3f}')
-
-    #     mission = {
-    #         "name": mission_name,
-    #         "group_id": "mirconst-guid-0000-0001-missiongroup",
-    #         "description": "automatically created by mir fleet adapter"
-    #         }
-    #     response = self.mir_api.missions_post(json.dumps(mission))
-
-    #     action = {
-    #         "action_type": "move_to_position",
-    #         "mission_id": response['guid'],
-    #         "priority": 1,
-    #         "parameters":[
-    #             {"id": "x", "value": mir_location.x},
-    #             {"id": "y", "value": mir_location.y},
-    #             {"id": "orientation", "value": mir_location.yaw},
-    #             {"id": "retries", "value": retries},
-    #             {"id": "distance_threshold", "value": 0.1}
-    #         ]
-    #     }
-
-    #     self.mir_api.missions_mission_id_actions_post(
-    #         mission_id=response['guid'],
-    #         body=action
-    #     )
-    #     self.node.get_logger().info(
-    #         f'{self.name}: '
-    #         f'Created mission to move coordinate to "{mir_location}"'
-    #     )
-
-    #      #NOTE(CH3): Unsure if I should be doing this
-    #     self.mir_missions[mission_name] = response['guid']
-    #     return response['guid']
 
     def queue_dock_mission(self, dock_name):
         """Add a dock mission to the mission queue, creating when needed."""

--- a/fleet_adapter_mir/fleet_adapter_mir.py
+++ b/fleet_adapter_mir/fleet_adapter_mir.py
@@ -196,6 +196,13 @@ def create_robot_command_handles(config, handle_data, dry_run=False):
 
             robot.load_mir_missions()
             robot.load_mir_positions()
+
+            # Check that the MiR fleet has defined the variable move mission,
+            # that this adapter will use repeatedly with varying parameters.
+            variable_move_mission = mir_config['variable_move_mission']
+            assert variable_move_mission in robot.mir_missions, \
+                (f'Variable move mission [{variable_move_mission}] not yet defined in mir_config')
+            robot.mir_variable_move_mission = variable_move_mission
         else:
             robot.mir_name = "DUMMY_ROBOT_FOR_DRY_RUN"
 

--- a/fleet_adapter_mir/fleet_adapter_mir.py
+++ b/fleet_adapter_mir/fleet_adapter_mir.py
@@ -201,8 +201,15 @@ def create_robot_command_handles(config, handle_data, dry_run=False):
             # that this adapter will use repeatedly with varying parameters.
             variable_move_mission = mir_config['variable_move_mission']
             assert variable_move_mission in robot.mir_missions, \
-                (f'Variable move mission [{variable_move_mission}] not yet defined in mir_config')
+                (f'Variable move mission [{variable_move_mission}] not yet defined as a mission in MiR fleet')
             robot.mir_variable_move_mission = variable_move_mission
+
+            if 'dock_and_charge_mission' in mir_config:
+                dock_and_charge_mission = mir_config['dock_and_charge_mission']
+                assert dock_and_charge_mission in robot.mir_missions, \
+                (f'Dock and charge mission [{dock_and_charge_mission}] not yet defined as a mission in MiR fleet')
+                robot.mir_dock_and_charge_mission = dock_and_charge_mission
+
         else:
             robot.mir_name = "DUMMY_ROBOT_FOR_DRY_RUN"
 

--- a/fleet_adapter_mir/fleet_adapter_mir.py
+++ b/fleet_adapter_mir/fleet_adapter_mir.py
@@ -230,12 +230,13 @@ def create_robot_command_handles(config, handle_data, dry_run=False):
             )
         assert starts, ("Robot %s can't be placed on the nav graph!"
                         % robot_name)
+        assert len(starts) != 0, (f'No StartSet found for robot: {robot_name}')
 
         # Insert start data into robot
         start = starts[0]
 
         if start.lane is not None:  # If the robot is in a lane
-            robot.rmf_current_lane_index = start.lane.value
+            robot.rmf_current_lane_index = start.lane
             robot.rmf_current_waypoint_index = None
             robot.rmf_target_waypoint_index = None
         else:  # Otherwise, the robot is on a waypoint

--- a/fleet_adapter_mir/fleet_adapter_mir.py
+++ b/fleet_adapter_mir/fleet_adapter_mir.py
@@ -197,12 +197,12 @@ def create_robot_command_handles(config, handle_data, dry_run=False):
             robot.load_mir_missions()
             robot.load_mir_positions()
 
-            # Check that the MiR fleet has defined the variable move mission,
+            # Check that the MiR fleet has defined the RMF move mission,
             # that this adapter will use repeatedly with varying parameters.
-            variable_move_mission = mir_config['variable_move_mission']
-            assert variable_move_mission in robot.mir_missions, \
-                (f'Variable move mission [{variable_move_mission}] not yet defined as a mission in MiR fleet')
-            robot.mir_variable_move_mission = variable_move_mission
+            rmf_move_mission = mir_config['rmf_move_mission']
+            assert rmf_move_mission in robot.mir_missions, \
+                (f'RMF move mission [{rmf_move_mission}] not yet defined as a mission in MiR fleet')
+            robot.mir_rmf_move_mission = rmf_move_mission
 
             if 'dock_and_charge_mission' in mir_config:
                 dock_and_charge_mission = mir_config['dock_and_charge_mission']


### PR DESCRIPTION
Fixes: https://github.com/osrf/fleet_adapter_mir/issues/7

* Move missions should be a predefined variable mission, so no additional missions are posted to the MiR server whenever commanded.
* Docking uses a predefined mission too.
* A `charge` finishing_request, executes the `dock` command successfully, tested on hardware, however once docked and charging starts, it was found that the fleet adapter is unable to interrupt it and send new commands even though the robot is fully charged, https://github.com/osrf/fleet_adapter_mir/issues/17
