### PR TITLE
Add missing argument when checking for fleet delivery capability

### DIFF
--- a/fleet_adapter_mir/fleet_adapter_mir.py
+++ b/fleet_adapter_mir/fleet_adapter_mir.py
@@ -157,7 +157,7 @@ def create_fleet(config,nav_graph_path, mock):
         fleet.consider_patrol_requests(lambda desc: always_accept)
     if task_capabilities_config['delivery']:
         print(f"Fleet [{fleet_name}] is configured to perform Delivery tasks")
-        fleet.consider_delivery_requests(lambda desc: always_accept)
+        fleet.consider_delivery_requests(lambda desc: always_accept, lambda desc: always_accept)
 
     # Whether to accept custom RMF action tasks
     def _consider(description: dict):


### PR DESCRIPTION
There is a small bug preventing the MiR fleet adapter to be used with delivery task. This PR aims to solve it.

If setting the delivery task capability to `True` in the config, the following crash would happen when trying to launch the fleet adapter:
```
ros2 run fleet_adapter_mir fleet_adapter_mir -c $CONFIG_FILE -n $NAV_GRAPH -d
Starting mir fleet adapter...

== Initialising MiR Robot Command Handles with Config ==
{'node_names': {'fleet_state_publisher': 'rmf_mir_fleet_state_publisher',
                'rmf_fleet_adapter': 'TestDeliveryAdapter',
                'robot_command_handle': 'rmf_mir_fleet_command_handler'},
 'reference_coordinates': {'mir': [[30.65, 6.7],
                                   [23.1, 6.85],
                                   [22.0, 13.0],
                                   [31.3, 9.3]],
                           'rmf': [[3.095, -11.2258],
                                   [10.3341, -9.4423],
                                   [13.5864, -15.0028],
                                   [3.3573, -14.0595]]},
 'rmf_fleet': {'account_for_battery_drain': True,
               'ambient_system': {'power': 20.0},
               'battery_system': {'capacity': 40.0,
                                  'charging_current': 26.4,
                                  'voltage': 24.0},
               'cleaning_system': {'power': 650.0},
               'fleet_state_publish_frequency': 1,
               'fleet_state_topic': 'fleet_states',
               'limits': {'angular': [1.0, 0.45], 'linear': [0.7, 0.3]},
               'mechanical_system': {'friction_coefficient': 0.2,
                                     'mass': 80.0,
                                     'moment_of_inertia': 20.0},
               'name': 'test_fleet',
               'profile': {'footprint': 0.4, 'vicinity': 0.5},
               'publish_fleet_state': True,
               'recharge_soc': 1.0,
               'recharge_threshold': 0.01,
               'reversible': False,
               'task_capabilities': {'action_categories': ['custom_mission_1'],
                                     'clean': False,
                                     'delivery': False,
                                     'finishing_request': 'nothing',
                                     'loop': True}},
 'robots': {'my_test_robot': {'mir_config': {'base_url':   <REMOVED FFROM LOG FOR SECURITY REASONS>,
                                             'dock_and_charge_mission': 'docking_mission_test',
                                             'password': 'Basic '
                                                         <REMOVED FROM LOG FOR SECURITY REASONS>,
                                             'rmf_move_mission': 'rmf_default_move_mission',
                                             'user': 'application/json'},
                              'rmf_config': {'charger': {'waypoint': 'charger_waypoint'},
                                             'robot_state_update_frequency': 1,
                                             'start': {'map_name': 'L1',
                                                       'max_merge_lane_distance': 3.0,
                                                       'max_merge_waypoint_distance': 3.0}}}}}

Fleet [test_fleet] is configured to perform Loop tasks
Fleet [test_fleet] is configured to perform action of category [custom_mission_1]
Traceback (most recent call last):
  File "/rmf_demos_ws/install/fleet_adapter_mir/lib/fleet_adapter_mir/fleet_adapter_mir", line 33, in <module>
    sys.exit(load_entry_point('fleet-adapter-mir==0.1.0', 'console_scripts', 'fleet_adapter_mir')())
  File "/rmf_demos_ws/install/fleet_adapter_mir/lib/python3.10/site-packages/fleet_adapter_mir/fleet_adapter_mir.py", line 351, in main
    robots = create_robot_command_handles(config, handle_data, dry_run=dry_run)
  File "/rmf_demos_ws/install/fleet_adapter_mir/lib/python3.10/site-packages/fleet_adapter_mir/fleet_adapter_mir.py", line 250, in create_robot_command_handles
    assert starts, ("Robot %s can't be placed on the nav graph!"
AssertionError: Robot my_test_robot can't be placed on the nav graph!
[ros2run]: Process exited with failure 1

```

This is due to this function call : https://github.com/osrf/fleet_adapter_mir/blob/92c457d7713f5c12ccad1208a85d445d937c6635/fleet_adapter_mir/fleet_adapter_mir.py#L160

`consider_delivery_request` needs a confirmation for both pickup and dropoff. This is fixed in this PR.

**This solution was tested successfully on a real MiR100. The fleet adapter is running and able to carry out delivery tasks.**